### PR TITLE
elf: Fix for mismatched app ELF file not detected. (IDFGH-9855)

### DIFF
--- a/esp_coredump/corefile/elf.py
+++ b/esp_coredump/corefile/elf.py
@@ -113,6 +113,8 @@ class ElfFile(object):
         self.load_segments = []  # type: list[ElfSegment]
         self.note_segments = []  # type: list[ElfNoteSegment]
 
+        self.sha256 = b''  # type: bytes
+
         if elf_path and os.path.isfile(elf_path):
             self.read_elf(elf_path)
 
@@ -142,6 +144,13 @@ class ElfFile(object):
                                     sec.sh.sh_addr,
                                     sec.data,
                                     sec.sh.sh_flags) for sec in self._model.sections]
+
+        # calculate sha256 of the input bytes (note: this may not be the same as the sha256 of any generated
+        # output struct, as the ELF parser may change some details.)
+        sha256 = hashlib.sha256()
+        sha256.update(elf_bytes)
+        self.sha256 = sha256.digest()
+
 
     @staticmethod
     def _parse_string_table(byte_str, offset):  # type: (bytes, int) -> str
@@ -201,15 +210,6 @@ class ElfFile(object):
             args.append('string_table' / Pointer(string_table_sh.sh_offset, Bytes(string_table_sh.sh_size)))
 
         return Struct(*args)
-
-    @property
-    def sha256(self):  # type: () -> bytes
-        """
-        :return: SHA256 hash of the input ELF file
-        """
-        sha256 = hashlib.sha256()
-        sha256.update(self._struct.build(self._model))  # type: ignore
-        return sha256.digest()
 
 
 class ElfSection(object):

--- a/esp_coredump/corefile/elf.py
+++ b/esp_coredump/corefile/elf.py
@@ -271,6 +271,13 @@ class ElfNoteSegment(ElfSegment):
         super(ElfNoteSegment, self).__init__(addr, data, flags)
         self.type = ElfFile.PT_NOTE
         self.note_secs = NoteSections.parse(self.data)
+        for note in self.note_secs:
+            # note.name should include a terminating NUL byte, plus possible
+            # padding
+            #
+            # (note: construct.PaddingString can't parse this if there
+            # are non-zero padding bytes after the NUL, it also parses those.)
+            note.name = note.name.split(b'\x00')[0]
 
     @staticmethod
     def _type_str():  # type: () -> str

--- a/esp_coredump/corefile/loader.py
+++ b/esp_coredump/corefile/loader.py
@@ -268,10 +268,20 @@ class EspCoreDumpLoader(EspCoreDumpVersion):
                         'sha256' / Bytes(64)  # SHA256 as hex string
                     )
                     coredump_sha256 = coredump_sha256_struct.parse(note_sec.desc[:coredump_sha256_struct.sizeof()])
-                    if coredump_sha256.sha256 != app_sha256:
+
+                    logging.debug('App SHA256: {!r}'.format(app_sha256))
+                    logging.debug('Core dump SHA256: {!r}'.format(coredump_sha256))
+
+                    # Actual coredump SHA may be shorter than a full SHA256 hash
+                    # with NUL byte padding, according to the app's APP_RETRIEVE_LEN_ELF_SHA
+                    # length
+                    core_sha_trimmed = coredump_sha256.sha256.rstrip(b'\x00').decode()
+                    app_sha_trimmed = app_sha256[:len(core_sha_trimmed)].decode()
+
+                    if core_sha_trimmed != app_sha_trimmed:
                         raise ESPCoreDumpLoaderError(
-                            'Invalid application image for coredump: coredump SHA256({!r}) != app SHA256({!r}).'
-                            .format(coredump_sha256, app_sha256))
+                            'Invalid application image for coredump: coredump SHA256({}) != app SHA256({}).'
+                            .format(core_sha_trimmed, app_sha_trimmed))
                     if coredump_sha256.ver != self.version:
                         raise ESPCoreDumpLoaderError(
                             'Invalid application image for coredump: coredump SHA256 version({}) != app SHA256 version({}).'

--- a/esp_coredump/corefile/loader.py
+++ b/esp_coredump/corefile/loader.py
@@ -258,7 +258,7 @@ class EspCoreDumpLoader(EspCoreDumpVersion):
         for seg in core_elf.note_segments:
             for note_sec in seg.note_secs:
                 # Check for version info note
-                if note_sec.name == 'ESP_CORE_DUMP_INFO' \
+                if note_sec.name == b'ESP_CORE_DUMP_INFO' \
                         and note_sec.type == ESPCoreDumpElfFile.PT_INFO \
                         and exe_name:
                     exe_elf = ElfFile(exe_name)


### PR DESCRIPTION
The check that the app ELF file SHA256 matches the one stored in the core dump would never fail, leading to gdb loading the wrong ELF file and either crashing or producing misleading debug information.

Specifics:

The `note_sec.name` field was incorrectly read back as `b'ESP_CORE_DUMP_INFO\x00E'`, because the `namesz` length includes the terminating NUL byte and possible junk padding bytes:
https://github.com/espressif/esp-idf/blob/master/components/espcoredump/src/core_dump_elf.c#L212

In addition, as `note_sec.name` is a bytes object Python 3 would have never successfully compared it with a string.